### PR TITLE
support for SLURM 17.02 - #77

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,9 @@ matrix:
 env:
   - IMAGE_BUILD_PLATFORM=stable-centos7
   - IMAGE_BUILD_PLATFORM=devel-centos7
-#  - IMAGE_BUILD_PLATFORM=epel-centos7
+  - IMAGE_BUILD_PLATFORM=fgcislurm1702
+  - IMAGE_BUILD_PLATFORM=fgcislurm1605
+  - IMAGE_BUILD_PLATFORM=fgcislurm1508
 
 install:
   - npm install -g validate-dockerfile
@@ -36,7 +38,7 @@ before_script:
 
 script:
   # Testing of this ansible-role:
-  - docker exec -ti $DOCKER_CONTAINER_ID /bin/sh -c "/$ROLETOTEST/tests/test-in-docker-image.sh"
+  - docker exec -ti $DOCKER_CONTAINER_ID /bin/sh -c "/$ROLETOTEST/tests/test-in-docker-image.sh $IMAGE_BUILD_PLATFORM"
 after_script:
   - >
     docker exec -ti $DOCKER_CONTAINER_ID /bin/sh -c 'echo -ne "------\nEND ANSIBLE TESTS\n------\nSystemD Units:\n------\n";

--- a/README.md
+++ b/README.md
@@ -6,17 +6,18 @@ ansible-role-slurm
 # Creates a SLURM cluster
 
 Tested with SLURM versions:
- - 14.11.0
- - 14.11.3
+ - 14.11.x
  - 15.08.x
  - 16.05.x
+ - 17.02.x
 
 Tested with these Linux distributions:
  - CentOS 6
   - Only 14.11.x
  - CentOS 7
-  - 15.08.x
-  - 16.05.x
+  - 15.08.x (travis ci automatic testing)
+  - 16.05.x (travis ci automatic testing)
+  - 17.02.x (travis ci automatic testing)
 
 ## Dependencies
 
@@ -80,6 +81,14 @@ Example Playbook
 
  - This role used to be able to build slurm rpms, distribute them and install them. The last tag/release that had this feature was v1.5.0
  - Setting up a shared directory á la NFS for running a SLURM in HA is out of scope for this role. There are many [NFS server roles](https://github.com/CSCfi/ansible-role-nfs) and [Mount Filesystem roles](https://github.com/CSCfi/ansible-role-nfs_mount) roles out there.
+
+### Testing and contributions
+
+Testing is done with [Travis](.travis.yml). New SLURM release can be tested after the RPMs are built and available in the FGCI repo. After that one needs to add a new tests/test1702.yml and a new IMAGE_BUILD_PLATFORM env in .travis.yml.
+
+ - PRs to master
+ - if possible make sure that the new feature is also tested
+ - strive for backwards compatibility
 
 # Authors / Contributors:
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,8 @@
 #
 
 # Packages installed everywhere
-slurm_packages:
+
+slurm_packages_before_1702:
  - slurm
  - slurm-devel
  - slurm-perlapi
@@ -14,6 +15,15 @@ slurm_packages:
  - slurm-munge
  - slurm-sjobexit
  - slurm-seff
+
+slurm_packages:
+ - slurm
+ - slurm-devel
+ - slurm-perlapi
+ - slurm-pam_slurm
+ - slurm-torque
+ - slurm-munge
+ - slurm-contribs
 # - slurm-spank-x11
 #
 
@@ -23,7 +33,6 @@ slurm_service_packages:
   - mailx
   - slurm-lua
   - slurm-plugins
-  - slurm-slurmdb-direct
   - slurm-sql
 
 admingroup: "admin"
@@ -39,7 +48,7 @@ slurm_manage_mysql_security: True
 nis_server: False
 
 fgci_install: True
-fgci_slurmrepo_version: "fgcislurm1508"
+fgci_slurmrepo_version: "fgcislurm1702"
 siteName: "io"
 nodeBase: "{{ siteName }}"
 nodeGpuBase: "gpu"

--- a/tasks/common.yml
+++ b/tasks/common.yml
@@ -13,10 +13,19 @@
     when: ansible_distribution_major_version == "7" and fgci_install == True and ansible_os_family == "RedHat"
 
 ##
-  - name: install common Slurm packages
+  - name: install common Slurm packages after 1605
     package: name={{ item }} state=present
     with_items: "{{ slurm_packages }}"
-    when: slurm_packages.0 != ""
+    when:
+     - slurm_packages.0 != ""
+     - slurm_fact_fgci_slurmrepo_version|int > 1605
+
+  - name: install common Slurm packages before 1702
+    package: name={{ item }} state=present
+    with_items: "{{ slurm_packages_before_1702 }}"
+    when:
+     - slurm_packages_before_1702.0 != ""
+     - slurm_fact_fgci_slurmrepo_version|int < 1702
 
   - name: install fgci Slurm addons
     package: name=slurm-fgi-addons state=present

--- a/tasks/compute.yml
+++ b/tasks/compute.yml
@@ -33,9 +33,12 @@
   - name: Create namespace epilog script
     template: src=namespace_clean.sh.j2 dest=/usr/local/libexec/slurm/epilog.d/namespace_clean.sh owner=root group=root mode=0755
 
-  - name: disable the slurm init script slurm on el7 compute nodes
+  - name: disable the slurm init script slurm on el7 on compute nodes before 1702
     service: name=slurm enabled=no
-    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "7"
+    when:
+      - ansible_os_family == "RedHat"
+      - ansible_distribution_major_version == "7"
+      - slurm_fact_fgci_slurmrepo_version|int < 1702
 
   - name: create systemd override directories for slurmd
     file: path="/etc/systemd/system/slurmd.service.d" state=directory owner=root mode=0755

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -3,6 +3,11 @@
     package: "name={{ item }} state=present"
     with_items: "{{ slurm_service_packages }}"
 
+  - name: install slurm-slurmdb-direct if before 1702
+    package: "name=slurm-slurmdb-direct state=present"
+    when:
+     - slurm_fact_fgci_slurmrepo_version|int < 1702
+
   - name: does the munge.key exist?
     stat: path=/etc/munge/munge.key
     register: mungekeystat

--- a/tasks/slurmctld.yml
+++ b/tasks/slurmctld.yml
@@ -15,6 +15,13 @@
   - name: start and enable munge on slurmctlds
     service: name=munge state=started enabled=yes
 
+  - name: disable the slurm init script slurm on el7 on slurmctlds before 1702
+    service: name=slurm enabled=no
+    when:
+      - ansible_os_family == "RedHat"
+      - ansible_distribution_major_version == "7"
+      - slurm_fact_fgci_slurmrepo_version|int < 1702
+
   - name: Increase net.core.somaxconn for slurmctld
     sysctl: name=net.core.somaxconn
             value={{ slurm_sysctl_core_somaxconn }}
@@ -26,10 +33,6 @@
             value={{ slurm_sysctl_tcp_max_syn_backlog }}
             sysctl_file=/etc/sysctl.d/50-slurm.conf
     when: slurm_manage_sysctl
-
-  - name: disable the slurm init script slurm on el7 on slurmctlds
-    service: name=slurm enabled=no
-    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "7"
 
   - name: create systemd override directories for slurmctld
     file: path="/etc/systemd/system/slurmctld.service.d" state=directory owner=root mode=0755

--- a/tests/fgcislurm1508
+++ b/tests/fgcislurm1508
@@ -1,0 +1,1 @@
+fgcislurm1605

--- a/tests/fgcislurm1605/Dockerfile
+++ b/tests/fgcislurm1605/Dockerfile
@@ -1,0 +1,21 @@
+# Latest version of centos
+FROM centos:centos7
+MAINTAINER James Cuzella <james.cuzella@lyraphase.com>
+RUN yum clean all && \
+    yum -y install epel-release && \
+    yum -y groupinstall "Development tools" && \
+    yum -y install python-devel MySQL-python sshpass && \
+    yum -y install acl sudo && \
+    sed -i -e 's/^Defaults.*requiretty/Defaults    !requiretty/' -e 's/^%wheel.*ALL$/%wheel    ALL=(ALL)    NOPASSWD: ALL/' /etc/sudoers && \
+    yum -y install PyYAML python-jinja2 python-httplib2 python-keyczar python-paramiko python-setuptools git python-pip \
+    pip install pyrax pysphere boto passlib dnspython && \
+    yum -y remove $(rpm -qa "*-devel") && \
+    yum -y groupremove "Development tools" && \
+    yum -y autoremove && \
+    yum -y install bzip2 crontabs file findutils gem git gzip hg procps-ng svn sudo tar tree which unzip xz zip
+
+RUN mkdir /etc/ansible/
+RUN echo -e '[local]\nlocalhost' > /etc/ansible/hosts
+RUN pip install ansible
+
+CMD ["/bin/bash"]

--- a/tests/fgcislurm1702
+++ b/tests/fgcislurm1702
@@ -1,0 +1,1 @@
+fgcislurm1605

--- a/tests/test-in-docker-image.sh
+++ b/tests/test-in-docker-image.sh
@@ -9,9 +9,18 @@ OS_TYPE=${1:-}
 OS_VERSION=${2:-}
 ANSIBLE_VERSION=${3:-}
 
-ANSIBLE_VAR=""
+# So if we get fgcislurm as the first bash argument to this script we
+#  change playbook to a slurm specific version.
+# This means to test a new SLURM version we need to add a new playbook.
+if [[ $OS_TYPE = *"fgcislurm"* ]]; then
+  ANSIBLE_VAR=""
+  SLURMVERSION=$(echo $OS_TYPE|tr -d 'fgcislurm')
+  ANSIBLE_PLAYBOOk="tests/test$SLURMVERSION.yml"
+else
+  ANSIBLE_VAR=""
+  ANSIBLE_PLAYBOOk="tests/test.yml"
+fi
 ANSIBLE_INVENTORY="tests/inventory"
-ANSIBLE_PLAYBOOk="tests/test.yml"
 #ANSIBLE_LOG_LEVEL=""
 ANSIBLE_LOG_LEVEL="-v"
 
@@ -21,7 +30,7 @@ if [ "x$SUDO" == "x" ];then
 fi
 
 ANSIBLE_EXTRA_VARS=""
-if [ "${ANSIBLE_VAR}x" == "x" ];then
+if [ "${ANSIBLE_VAR}x" != "x" ];then
     ANSIBLE_EXTRA_VARS=" -e \"${ANSIBLE_VAR}\" "
 fi
 

--- a/tests/test1508.yml
+++ b/tests/test1508.yml
@@ -1,6 +1,7 @@
 ---
 
- - hosts: install,compute
+ - name: install a SLURM 1508 cluster
+   hosts: install,compute
    remote_user: root
    roles:
      - ansible-role-pam
@@ -26,7 +27,7 @@
        - { match: "{gpu[2-22]}", name: "check_hw_ib", arguments: "56" }
        - { match: "*", name: "check_hw_eth", arguments: "eth0" }
      - slurm_plugstack: True
-     - fgci_slurmrepo_version: "fgcislurm1702"
+     - fgci_slurmrepo_version: "fgcislurm1508"
      - slurm_x11_spank: True
      - slurm_topology_plugin: "topology/tree"
      - slurm_topologylist: 
@@ -36,6 +37,15 @@
      - slurm_systemd_override_slurmdbd: True
      - slurm_systemd_override_slurmctld: True
      - slurm_SlurmctldTimeout: 10
+     - slurm_packages_before_1702:
+       - slurm
+       - slurm-devel
+       - slurm-perlapi
+       - slurm-pam_slurm
+       - slurm-sjstat
+       - slurm-torque
+       - slurm-munge
+       - slurm-sjobexit
 
 
    pre_tasks:

--- a/tests/test1605.yml
+++ b/tests/test1605.yml
@@ -1,6 +1,7 @@
 ---
 
- - hosts: install,compute
+ - name: install a SLURM 1605 cluster
+   hosts: install,compute
    remote_user: root
    roles:
      - ansible-role-pam
@@ -26,7 +27,7 @@
        - { match: "{gpu[2-22]}", name: "check_hw_ib", arguments: "56" }
        - { match: "*", name: "check_hw_eth", arguments: "eth0" }
      - slurm_plugstack: True
-     - fgci_slurmrepo_version: "fgcislurm1702"
+     - fgci_slurmrepo_version: "fgcislurm1605"
      - slurm_x11_spank: True
      - slurm_topology_plugin: "topology/tree"
      - slurm_topologylist: 

--- a/tests/test1702.yml
+++ b/tests/test1702.yml
@@ -1,6 +1,7 @@
 ---
 
- - hosts: install,compute
+ - name: install a SLURM 1702 cluster
+   hosts: install,compute
    remote_user: root
    roles:
      - ansible-role-pam


### PR DESCRIPTION
Attempt 1 at a PR to support SLURM 17.02.

Comments in regards to the backwards compatibility with SLURM 16.05?

---

This role no longer works with a SLURM earlire than 17.02 as of this
commit.

 - install slurm-contribs instead of slurm-sjstat,sjobexit,seff
 - no longer install slurm-slurmdb-direct
 - no longer disable slurm initd script
 - change fgci_slurmrepo_version default from pointing to yum repo
with 15.08 to one with 17.02