### PR TITLE
kill -SIGUSR2 for logrotate

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -84,6 +84,7 @@ slurm_TaskPlugin: "task/cgroup"
 slurm_log_dir: "/var/log/slurm"
 slurm_logrotate_rotate_interval: "weekly"
 slurm_logrotate_rotate: "8"
+slurm_logrotate_signal: "-SIGUSR2"
 slurm_state_dir: "/opt/slurmdb/tmp"
 
 slurm_switch_type: "switch/none"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -84,7 +84,7 @@ slurm_TaskPlugin: "task/cgroup"
 slurm_log_dir: "/var/log/slurm"
 slurm_logrotate_rotate_interval: "weekly"
 slurm_logrotate_rotate: "8"
-slurm_logrotate_signal: "-SIGUSR2"
+slurm_logrotate_signal: "-HUP"
 slurm_state_dir: "/opt/slurmdb/tmp"
 
 slurm_switch_type: "switch/none"

--- a/templates/slurm_logrotate.j2
+++ b/templates/slurm_logrotate.j2
@@ -9,7 +9,7 @@
 	compress
 	create 644 slurm slurm
 	postrotate
-		/bin/kill -SIGUSR2 $(cat /var/run/slurmdbd.pid) 2>/dev/null 2> /dev/null || true
+		/bin/kill {{ slurm_logrotate_signal }} $(cat /var/run/slurmdbd.pid) 2>/dev/null 2> /dev/null || true
 	endscript
 }
 {{ slurm_log_dir }}/slurm.log {
@@ -22,8 +22,8 @@
 	compress
 	create 644 slurm slurm
 	postrotate
-		/bin/kill -SIGUSR2 $(cat /var/run/slurmctld.pid) 2>/dev/null 2> /dev/null || true
-		/bin/kill -SIGUSR2 $(cat /var/run/syslogd.pid) 2> /dev/null 2> /dev/null || true
+		/bin/kill {{ slurm_logrotate_signal }} $(cat /var/run/slurmctld.pid) 2>/dev/null 2> /dev/null || true
+		/bin/kill {{ slurm_logrotate_signal }} $(cat /var/run/syslogd.pid) 2> /dev/null 2> /dev/null || true
 	endscript
 }
 {{ slurm_log_dir }}/slurm_jobcomp.log {
@@ -36,7 +36,7 @@
 	compress
 	create 644 slurm slurm
 	postrotate
-		/bin/kill -SIGUSR2 $(cat /var/run/slurmctld.pid) 2>/dev/null 2> /dev/null || true
+		/bin/kill {{ slurm_logrotate_signal }} $(cat /var/run/slurmctld.pid) 2>/dev/null 2> /dev/null || true
 	endscript
 }
 {% endif %}

--- a/templates/slurm_logrotate.j2
+++ b/templates/slurm_logrotate.j2
@@ -9,7 +9,7 @@
 	compress
 	create 644 slurm slurm
 	postrotate
-		/bin/kill -HUP cat /var/run/slurmdbd.pid 2>/dev/null 2> /dev/null || true
+		/bin/kill -SIGUSR2 $(cat /var/run/slurmdbd.pid) 2>/dev/null 2> /dev/null || true
 	endscript
 }
 {{ slurm_log_dir }}/slurm.log {
@@ -22,8 +22,8 @@
 	compress
 	create 644 slurm slurm
 	postrotate
-		/bin/kill -HUP cat /var/run/slurmctld.pid 2>/dev/null 2> /dev/null || true
-		/bin/kill -HUP cat /var/run/syslogd.pid 2> /dev/null 2> /dev/null || true
+		/bin/kill -SIGUSR2 $(cat /var/run/slurmctld.pid) 2>/dev/null 2> /dev/null || true
+		/bin/kill -SIGUSR2 $(cat /var/run/syslogd.pid) 2> /dev/null 2> /dev/null || true
 	endscript
 }
 {{ slurm_log_dir }}/slurm_jobcomp.log {
@@ -36,7 +36,7 @@
 	compress
 	create 644 slurm slurm
 	postrotate
-		/bin/kill -HUP cat /var/run/slurmctld.pid 2>/dev/null 2> /dev/null || true
+		/bin/kill -SIGUSR2 $(cat /var/run/slurmctld.pid) 2>/dev/null 2> /dev/null || true
 	endscript
 }
 {% endif %}


### PR DESCRIPTION
https://slurm.schedmd.com/SLUG17/Roadmap.pdf says to use SIGUSR2 instead
of HUP. This only works with SLURM 17.11. 

HUP runs a reconfigure which can cause performance issues.

Additionally, before this commit the kill command was:

<pre>
/bin/kill -HUP cat /var/run/slurmctld.pid 2>/dev/null 2> /dev/null || true
</pre>

Running that command directly does not seem to work (and errors are hidden by the stdout/stderr redirections):

<pre>
kill: cannot find process "cat"
kill: cannot find process "/var/run/slurmctld.pid"
</pre>

So put the cat inside a $()