### PR TITLE
Set task affinity per SchedMD recommendation

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -50,7 +50,7 @@ slurm_CacheGroups: "1"
 slurm_Prolog: "/etc/slurm/prolog"
 slurm_Epilog: "/usr/local/libexec/slurm/epilog.d/*"
 slurm_TaskEpilog: "/usr/bin/epilog"
-slurm_TaskPlugin: "task/cgroup"
+slurm_TaskPlugin: "task/affinity,task/cgroup"
 slurm_log_dir: "/var/log/slurm"
 slurm_logrotate_rotate_interval: "weekly"
 slurm_logrotate_rotate: "8"
@@ -163,7 +163,7 @@ slurm_cgroup_constrain_cores: "yes"
 slurm_cgroup_constrain_ram: "no" # Use the very strict cgroup-based memory tracker?
 slurm_cgroup_allowedramspace: "100.1" # At which % of requested memory should the process get killed?
 slurm_cgroup_constrain_swap: "no"
-slurm_cgroup_taskaffinity: "yes" 
+slurm_cgroup_taskaffinity: "no"
 slurm_cgroup_allowedswapspace: "120" # % of memory allocation that can be phys mem+swap
 slurm_cgroup_constrain_devices: "no" 
 slurm_cgroup_min_ram: "500" # always allocate this much memory to each job

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -160,7 +160,6 @@ slurm_healthcheck_interval: "300"
 slurm_cgroup_mountpoint: "/sys/fs/cgroup"
 slurm_cgroup_automount : "no"
 slurm_cgroup_constrain_cores: "yes"
-slurm_cgroup_cpu_affinity: "yes"
 slurm_cgroup_constrain_ram: "no" # Use the very strict cgroup-based memory tracker?
 slurm_cgroup_allowedramspace: "100.1" # At which % of requested memory should the process get killed?
 slurm_cgroup_constrain_swap: "no"


### PR DESCRIPTION
In the slurm.conf(5) man page it is recommended to use the
task/affinity plugin to set affinity and not use the task affinity
feature of the task/cgroup plugin. This makes the defaults match this
recommendation.