### PR TITLE
Support for SLURM version specific settings in slurm and slurmdbd.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,6 @@ ansible-role-slurm
 
 # Creates a SLURM cluster
 
-Tested with SLURM versions:
- - 14.11.x
- - 15.08.x
- - 16.05.x
- - 17.02.x
- - 17.11.x
-
 Tested with these Linux distributions:
  - CentOS 6
   - Only 14.11.x
@@ -20,6 +13,10 @@ Tested with these Linux distributions:
   - 16.05.x (travis ci automatic testing)
   - 17.02.x (travis ci automatic testing)
   - 17.11.x (travis ci automatic testing)
+
+The role goes to some lengths to be backwards compatible.
+
+For example in case we want to add default settings to slurm.conf in only some slurm versions we can do that by adding slurm_conf_version_specific_params_list to the version in vars/slurm\_version.yml
 
 ## Dependencies
 
@@ -48,14 +45,17 @@ user. See http://docs.ansible.com/ansible/playbooks_vault.html
 
 To add your own nodes and queues define the slurm_nodelist and slurm_partitionlist lists.
 
+You don't have to setup a SQL server with this role, it's here for convenience and if you want to run the SQL on the same node as the slurmctld and slurmdbd.
 It is possible to run the slurmdbd on a different host than the slurmctld by changing the slurm_accounting_storage_host variable.
 
 It is also possible to setup a backup slurm controller by defining slurm_backup_controller variable. Please read the [SLURM HA documentation](https://slurm.schedmd.com/quickstart_admin.html#HA). For example you'll need a shared directory (for example NFS) available on both the slurm_service_node and slurm_backup_controller.
 
-SLURM 16.05 can be gotten from the FGCI yum repo by setting:
+Specific versions of SLURM can be gotten from the FGCI yum repo by setting:
 <pre>
 fgci_slurmrepo_version: "fgcislurm1605"
 </pre>
+
+We have 1508,1605 and 1711 RPMs there.
 
 ### Implementation
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -171,9 +171,9 @@ slurm_cgroup_release_agent_dir: "/etc/slurm/cgroup"
 
 # LOGGING
 slurm_SlurmctldDebug: "3"
-slurmctld_syslog_debug: "info"
+slurm_slurmctld_syslog_debug: "info"
 slurm_SlurmdDebug: "3"
-slurmd_syslog_debug: "info"
+slurm_slurmd_syslog_debug: "info"
 slurm_JobCompLoc: "{{ slurm_log_dir }}/slurm_jobcomp.log"
 slurm_JobCompType: "jobcomp/filetxt"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -171,7 +171,9 @@ slurm_cgroup_release_agent_dir: "/etc/slurm/cgroup"
 
 # LOGGING
 slurm_SlurmctldDebug: "3"
+slurmctld_syslog_debug: "info"
 slurm_SlurmdDebug: "3"
+slurmd_syslog_debug: "info"
 slurm_JobCompLoc: "{{ slurm_log_dir }}/slurm_jobcomp.log"
 slurm_JobCompType: "jobcomp/filetxt"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -176,6 +176,7 @@ slurm_SlurmdDebug: "3"
 slurm_slurmd_syslog_debug: "info"
 slurm_JobCompLoc: "{{ slurm_log_dir }}/slurm_jobcomp.log"
 slurm_JobCompType: "jobcomp/filetxt"
+slurm_slurmdbd_syslog_debug: "info"
 
 # ACCOUNTING
 slurm_JobAcctGatherType: "jobacct_gather/linux"

--- a/templates/slurm.conf.j2
+++ b/templates/slurm.conf.j2
@@ -86,7 +86,9 @@ PriorityMaxAge={{ slurm_priority_maxage }}
 
 # LOGGING
 SlurmctldDebug={{ slurm_SlurmctldDebug }}
+SlurmctldSyslogDebug={{ slurmctld_syslog_debug }}
 SlurmdDebug={{ slurm_SlurmdDebug }}
+SlurmdSyslogDebug={{ slurmd_syslog_debug }}
 JobCompLoc={{ slurm_JobCompLoc }}
 JobCompType={{ slurm_JobCompType }}
 

--- a/templates/slurm.conf.j2
+++ b/templates/slurm.conf.j2
@@ -149,10 +149,8 @@ PartitionName=grid Nodes={{ slurm_compute_nodes }} Default=NO MaxTime={{ slurm_m
 {% endif %}
 
 {% if slurm_conf_version_specific_params_list is defined %}
-{% if slurm_conf_version_specific_params_list[0] %}
 # Slurm Version Specific Parameters
 {% for slurm_v_param in slurm_conf_version_specific_params_list %}
 {{ slurm_v_param }}
 {% endfor %}
-{% endif %}
 {% endif %}

--- a/templates/slurm.conf.j2
+++ b/templates/slurm.conf.j2
@@ -89,10 +89,6 @@ SlurmctldDebug={{ slurm_SlurmctldDebug }}
 SlurmdDebug={{ slurm_SlurmdDebug }}
 JobCompLoc={{ slurm_JobCompLoc }}
 JobCompType={{ slurm_JobCompType }}
-{% if slurm_fact_fgci_slurmrepo_version > 1702 %}
-SlurmdSyslogDebug={{ slurmd_syslog_debug }}
-SlurmctldSyslogDebug={{ slurmctld_syslog_debug }}
-{% endif %}
 
 # ACCOUNTING
 JobAcctGatherType={{ slurm_JobAcctGatherType }}

--- a/templates/slurm.conf.j2
+++ b/templates/slurm.conf.j2
@@ -148,10 +148,10 @@ PartitionName=grid Nodes={{ slurm_compute_nodes }} Default=NO MaxTime={{ slurm_m
 {% endfor %}
 {% endif %}
 
-{% if slurm_conf_version_specific_params is defined %}
-{% if slurm_conf_version_specific_params[0] %}
+{% if slurm_conf_version_specific_params_list is defined %}
+{% if slurm_conf_version_specific_params_list[0] %}
 # Slurm Version Specific Parameters
-{% for slurm_v_param in slurm_conf_version_specific_params %}
+{% for slurm_v_param in slurm_conf_version_specific_params_list %}
 {{ slurm_v_param }}
 {% endfor %}
 {% endif %}

--- a/templates/slurm.conf.j2
+++ b/templates/slurm.conf.j2
@@ -86,11 +86,13 @@ PriorityMaxAge={{ slurm_priority_maxage }}
 
 # LOGGING
 SlurmctldDebug={{ slurm_SlurmctldDebug }}
-SlurmctldSyslogDebug={{ slurmctld_syslog_debug }}
 SlurmdDebug={{ slurm_SlurmdDebug }}
-SlurmdSyslogDebug={{ slurmd_syslog_debug }}
 JobCompLoc={{ slurm_JobCompLoc }}
 JobCompType={{ slurm_JobCompType }}
+{% if slurm_fact_fgci_slurmrepo_version > 1702 %}
+SlurmdSyslogDebug={{ slurmd_syslog_debug }}
+SlurmctldSyslogDebug={{ slurmctld_syslog_debug }}
+{% endif %}
 
 # ACCOUNTING
 JobAcctGatherType={{ slurm_JobAcctGatherType }}
@@ -148,4 +150,13 @@ PartitionName=grid Nodes={{ slurm_compute_nodes }} Default=NO MaxTime={{ slurm_m
 {% for slurm_Param in slurm_ExtraParamsList %}
 {{ slurm_Param }}
 {% endfor %}
+{% endif %}
+
+{% if slurm_conf_version_specific_params is defined %}
+{% if slurm_conf_version_specific_params[0] %}
+# Slurm Version Specific Parameters
+{% for slurm_v_param in slurm_conf_version_specific_params %}
+{{ slurm_v_param }}
+{% endfor %}
+{% endif %}
 {% endif %}

--- a/templates/slurmdbd.conf.j2
+++ b/templates/slurmdbd.conf.j2
@@ -78,10 +78,8 @@ StorageUser=slurm
 StorageLoc=slurm_acct_db
 
 {% if slurm_slurmdbd_conf_version_specific_params_list is defined %}
-{% if slurm_slurmdbd_conf_version_specific_params_list[0] %}
 # Slurm Version Specific Parameters
 {% for slurm_v_param in slurm_slurmdbd_conf_version_specific_params_list %}
 {{ slurm_v_param }}
 {% endfor %}
-{% endif %}
 {% endif %}

--- a/templates/slurmdbd.conf.j2
+++ b/templates/slurmdbd.conf.j2
@@ -77,3 +77,11 @@ StoragePass={{ slurm_mysql_password }}
 StorageUser=slurm
 StorageLoc=slurm_acct_db
 
+{% if slurm_slurmdbd_conf_version_specific_params_list is defined %}
+{% if slurm_slurmdbd_conf_version_specific_params_list[0] %}
+# Slurm Version Specific Parameters
+{% for slurm_v_param in slurm_slurmdbd_conf_version_specific_params_list %}
+{{ slurm_v_param }}
+{% endfor %}
+{% endif %}
+{% endif %}

--- a/vars/slurm_1508.yml
+++ b/vars/slurm_1508.yml
@@ -11,11 +11,14 @@ slurm_packages:
  - slurm-sjobexit
 
 slurm_service_packages:
-  - lua-devel
-  - mailx
-  - slurm-lua
-  - slurm-plugins
-  - slurm-slurmdb-direct
-  - slurm-sql
+ - lua-devel
+ - mailx
+ - slurm-lua
+ - slurm-plugins
+ - slurm-slurmdb-direct
+ - slurm-sql
 
-slurm_conf_version_specific_params: ""
+slurm_conf_version_specific_params_list:
+ - ""
+slurm_slurmdbd_conf_version_specific_params_list:
+ - ""

--- a/vars/slurm_1508.yml
+++ b/vars/slurm_1508.yml
@@ -17,3 +17,5 @@ slurm_service_packages:
   - slurm-plugins
   - slurm-slurmdb-direct
   - slurm-sql
+
+slurm_conf_version_specific_settings: ""

--- a/vars/slurm_1508.yml
+++ b/vars/slurm_1508.yml
@@ -18,4 +18,4 @@ slurm_service_packages:
   - slurm-slurmdb-direct
   - slurm-sql
 
-slurm_conf_version_specific_settings: ""
+slurm_conf_version_specific_params: ""

--- a/vars/slurm_1508.yml
+++ b/vars/slurm_1508.yml
@@ -17,8 +17,3 @@ slurm_service_packages:
  - slurm-plugins
  - slurm-slurmdb-direct
  - slurm-sql
-
-slurm_conf_version_specific_params_list:
- - ""
-slurm_slurmdbd_conf_version_specific_params_list:
- - ""

--- a/vars/slurm_1605.yml
+++ b/vars/slurm_1605.yml
@@ -12,11 +12,14 @@ slurm_packages:
  - slurm-seff
 
 slurm_service_packages:
-  - lua-devel
-  - mailx
-  - slurm-lua
-  - slurm-plugins
-  - slurm-slurmdb-direct
-  - slurm-sql
+ - lua-devel
+ - mailx
+ - slurm-lua
+ - slurm-plugins
+ - slurm-slurmdb-direct
+ - slurm-sql
 
-slurm_conf_version_specific_params: ""
+slurm_conf_version_specific_params_list:
+ - ""
+slurm_slurmdbd_conf_version_specific_params_list:
+ - ""

--- a/vars/slurm_1605.yml
+++ b/vars/slurm_1605.yml
@@ -18,3 +18,5 @@ slurm_service_packages:
   - slurm-plugins
   - slurm-slurmdb-direct
   - slurm-sql
+
+slurm_conf_version_specific_settings: ""

--- a/vars/slurm_1605.yml
+++ b/vars/slurm_1605.yml
@@ -19,4 +19,4 @@ slurm_service_packages:
   - slurm-slurmdb-direct
   - slurm-sql
 
-slurm_conf_version_specific_settings: ""
+slurm_conf_version_specific_params: ""

--- a/vars/slurm_1605.yml
+++ b/vars/slurm_1605.yml
@@ -18,8 +18,3 @@ slurm_service_packages:
  - slurm-plugins
  - slurm-slurmdb-direct
  - slurm-sql
-
-slurm_conf_version_specific_params_list:
- - ""
-slurm_slurmdbd_conf_version_specific_params_list:
- - ""

--- a/vars/slurm_1702.yml
+++ b/vars/slurm_1702.yml
@@ -15,3 +15,5 @@ slurm_service_packages:
  - slurm-lua
  - slurm-plugins
  - slurm-sql
+
+slurm_conf_version_specific_settings: ""

--- a/vars/slurm_1702.yml
+++ b/vars/slurm_1702.yml
@@ -15,8 +15,3 @@ slurm_service_packages:
  - slurm-lua
  - slurm-plugins
  - slurm-sql
-
-slurm_conf_version_specific_params_list:
- - ""
-slurm_slurmdbd_conf_version_specific_params_list:
- - ""

--- a/vars/slurm_1702.yml
+++ b/vars/slurm_1702.yml
@@ -16,4 +16,4 @@ slurm_service_packages:
  - slurm-plugins
  - slurm-sql
 
-slurm_conf_version_specific_settings: ""
+slurm_conf_version_specific_params: ""

--- a/vars/slurm_1702.yml
+++ b/vars/slurm_1702.yml
@@ -16,4 +16,7 @@ slurm_service_packages:
  - slurm-plugins
  - slurm-sql
 
-slurm_conf_version_specific_params: ""
+slurm_conf_version_specific_params_list:
+ - ""
+slurm_slurmdbd_conf_version_specific_params_list:
+ - ""

--- a/vars/slurm_1711.yml
+++ b/vars/slurm_1711.yml
@@ -17,5 +17,5 @@ slurm_service_packages:
 slurm_compute_packages:
  - slurm-slurmd
 
-slurm_conf_version_specific_settings:
+slurm_conf_version_specific_params:
  - "# 17.11"

--- a/vars/slurm_1711.yml
+++ b/vars/slurm_1711.yml
@@ -16,3 +16,6 @@ slurm_service_packages:
 
 slurm_compute_packages:
  - slurm-slurmd
+
+slurm_conf_version_specific_settings:
+ - "# 17.11"

--- a/vars/slurm_1711.yml
+++ b/vars/slurm_1711.yml
@@ -17,6 +17,9 @@ slurm_service_packages:
 slurm_compute_packages:
  - slurm-slurmd
 
-slurm_conf_version_specific_params:
+slurm_conf_version_specific_params_list:
  - "SlurmctldSyslogDebug={{ slurm_slurmctld_syslog_debug }}"
  - "SlurmdSyslogDebug={{ slurm_slurmd_syslog_debug }}"
+
+slurm_slurmdbd_conf_version_specific_params_list:
+ - "DebugLevelSyslog={{ slurm_slurmdbd_syslog_debug }}"

--- a/vars/slurm_1711.yml
+++ b/vars/slurm_1711.yml
@@ -18,4 +18,5 @@ slurm_compute_packages:
  - slurm-slurmd
 
 slurm_conf_version_specific_params:
- - "# 17.11"
+ - "SlurmctldSyslogDebug={{ slurm_slurmctld_syslog_debug }}"
+ - "SlurmdSyslogDebug={{ slurm_slurmd_syslog_debug }}"

--- a/vars/slurm_default.yml
+++ b/vars/slurm_default.yml
@@ -15,6 +15,3 @@ slurm_service_packages:
  - slurm-lua
  - slurm-plugins
  - slurm-sql
-
-slurm_conf_version_specific_params_list:
- - ""

--- a/vars/slurm_default.yml
+++ b/vars/slurm_default.yml
@@ -10,8 +10,11 @@ slurm_packages:
  - slurm-contribs
 
 slurm_service_packages:
-  - lua-devel
-  - mailx
-  - slurm-lua
-  - slurm-plugins
-  - slurm-sql
+ - lua-devel
+ - mailx
+ - slurm-lua
+ - slurm-plugins
+ - slurm-sql
+
+slurm_conf_version_specific_params_list:
+ - ""


### PR DESCRIPTION
With this PR this ansible-role now supports setting vars by default in slurmdbd.conf and slurm.conf for some SLURM versions.
Already before a user of this role could set ansible variable {{ slurm_ExtraParamsList }} and it would add those to slurm.conf

Together with the above changes we with SLURM 17.11 (only) now set slurmdbd, slurmctld and slurmd syslog levels to "info" rather than the default "quiet" or "fatal".

The reason why the settings are not added into slurm.conf is because slurm does not start with unknown parameters in slurm.conf - it would have broken backwards compatibility with versions prior to 17.11.

Some background information: https://bugs.schedmd.com/show_bug.cgi?id=4514