### PR TITLE
Add syslog debug level flags

### DIFF
--- a/templates/slurm.conf.j2
+++ b/templates/slurm.conf.j2
@@ -86,7 +86,13 @@ PriorityMaxAge={{ slurm_priority_maxage }}
 
 # LOGGING
 SlurmctldDebug={{ slurm_SlurmctldDebug }}
+{% if slurm_SlurmctldSyslogDebug is defined %}
+SlurmctldSyslogDebug={{ slurm_SlurmctldSyslogDebug }}
+{% endif %}
 SlurmdDebug={{ slurm_SlurmdDebug }}
+{% if slurm_SlurmdSyslogDebug is defined %}
+SlurmdSyslogDebug={{ slurm_SlurmdSyslogDebug }}
+{% endif %}
 JobCompLoc={{ slurm_JobCompLoc }}
 JobCompType={{ slurm_JobCompType }}
 

--- a/templates/slurmdbd.conf.j2
+++ b/templates/slurmdbd.conf.j2
@@ -62,6 +62,9 @@ DbdHost={{ slurm_accounting_storage_host }}
 #DbdPort=7031
 SlurmUser=slurm
 #MessageTimeout=300
+{% if slurmdbd_DebugLevelSyslog is defined %}
+DebugLevelSyslog={{ slurmdbd_DebugLevelSyslog }}
+{% endif %}
 DebugLevel=4
 #DefaultQOS=normal,standby
 PidFile=/var/run/slurmdbd.pid


### PR DESCRIPTION
It seems that as of the 17.11 update slurmctld and slurmdbd won't log
anything unless syslog specific log level parameters are set in the
config files. slurmd's on the nodes do seem to happily log without the
corresponding setting, but lets add it anyway.