### PR TITLE
Remove CgroupReleaseAgentDir setting

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -167,7 +167,6 @@ slurm_cgroup_taskaffinity: "no"
 slurm_cgroup_allowedswapspace: "120" # % of memory allocation that can be phys mem+swap
 slurm_cgroup_constrain_devices: "no" 
 slurm_cgroup_min_ram: "500" # always allocate this much memory to each job
-slurm_cgroup_release_agent_dir: "/etc/slurm/cgroup"
 
 # LOGGING
 slurm_SlurmctldDebug: "3"

--- a/templates/cgroup.conf.j2
+++ b/templates/cgroup.conf.j2
@@ -9,7 +9,6 @@
 #
 CgroupMountpoint={{ slurm_cgroup_mountpoint }}
 CgroupAutomount={{ slurm_cgroup_automount }}
-CgroupReleaseAgentDir={{ slurm_cgroup_release_agent_dir }}
 
 ConstrainCores={{ slurm_cgroup_constrain_cores }}
 TaskAffinity={{ slurm_cgroup_taskaffinity }}


### PR DESCRIPTION
CgroupReleaseAgentDir has been deprecated, and current slurm versions
log a warning message if it's present in the cgroup config.