### PR TITLE
Set ConstrainKmemSpace=no by default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -160,6 +160,7 @@ slurm_healthcheck_interval: "300"
 slurm_cgroup_mountpoint: "/sys/fs/cgroup"
 slurm_cgroup_automount : "no"
 slurm_cgroup_constrain_cores: "yes"
+slurm_cgroup_constrain_kmem_space: "no" # Workaround for Linux kernel bug, see slurm bug #5082
 slurm_cgroup_constrain_ram: "no" # Use the very strict cgroup-based memory tracker?
 slurm_cgroup_allowedramspace: "100.1" # At which % of requested memory should the process get killed?
 slurm_cgroup_constrain_swap: "no"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -160,7 +160,6 @@ slurm_healthcheck_interval: "300"
 slurm_cgroup_mountpoint: "/sys/fs/cgroup"
 slurm_cgroup_automount : "no"
 slurm_cgroup_constrain_cores: "yes"
-slurm_cgroup_constrain_kmem_space: "no" # Workaround for Linux kernel bug, see slurm bug #5082
 slurm_cgroup_constrain_ram: "no" # Use the very strict cgroup-based memory tracker?
 slurm_cgroup_allowedramspace: "100.1" # At which % of requested memory should the process get killed?
 slurm_cgroup_constrain_swap: "no"

--- a/templates/cgroup.conf.j2
+++ b/templates/cgroup.conf.j2
@@ -13,7 +13,9 @@ CgroupReleaseAgentDir={{ slurm_cgroup_release_agent_dir }}
 
 ConstrainCores={{ slurm_cgroup_constrain_cores }}
 TaskAffinity={{ slurm_cgroup_taskaffinity }}
+{% if slurm_cgroup_constrain_kmem_space is defined %}
 ConstrainKmemSpace={{ slurm_cgroup_constrain_kmem_space }}
+{% endif ‰}
 ConstrainRAMSpace={{ slurm_cgroup_constrain_ram }}
 ConstrainSwapSpace={{ slurm_cgroup_constrain_swap }}
 AllowedRAMSpace={{ slurm_cgroup_allowedramspace }}

--- a/templates/cgroup.conf.j2
+++ b/templates/cgroup.conf.j2
@@ -13,6 +13,7 @@ CgroupReleaseAgentDir={{ slurm_cgroup_release_agent_dir }}
 
 ConstrainCores={{ slurm_cgroup_constrain_cores }}
 TaskAffinity={{ slurm_cgroup_taskaffinity }}
+ConstrainKmemSpace={{ slurm_cgroup_constrain_kmem_space }}
 ConstrainRAMSpace={{ slurm_cgroup_constrain_ram }}
 ConstrainSwapSpace={{ slurm_cgroup_constrain_swap }}
 AllowedRAMSpace={{ slurm_cgroup_allowedramspace }}

--- a/templates/cgroup.conf.j2
+++ b/templates/cgroup.conf.j2
@@ -15,7 +15,7 @@ ConstrainCores={{ slurm_cgroup_constrain_cores }}
 TaskAffinity={{ slurm_cgroup_taskaffinity }}
 {% if slurm_cgroup_constrain_kmem_space is defined %}
 ConstrainKmemSpace={{ slurm_cgroup_constrain_kmem_space }}
-{% endif ‰}
+{% endif %}
 ConstrainRAMSpace={{ slurm_cgroup_constrain_ram }}
 ConstrainSwapSpace={{ slurm_cgroup_constrain_swap }}
 AllowedRAMSpace={{ slurm_cgroup_allowedramspace }}

--- a/vars/slurm_1702.yml
+++ b/vars/slurm_1702.yml
@@ -15,3 +15,5 @@ slurm_service_packages:
  - slurm-lua
  - slurm-plugins
  - slurm-sql
+
+slurm_cgroup_constrain_kmem_space: "no" # Workaround for Linux kernel bug, see slurm bug #5082

--- a/vars/slurm_1711.yml
+++ b/vars/slurm_1711.yml
@@ -23,3 +23,5 @@ slurm_conf_version_specific_params_list:
 
 slurm_slurmdbd_conf_version_specific_params_list:
  - "DebugLevelSyslog={{ slurm_slurmdbd_syslog_debug }}"
+
+slurm_cgroup_constrain_kmem_space: "no" # Workaround for Linux kernel bug, see slurm bug #5082


### PR DESCRIPTION
Setting ConstrainKmemSpace=no works around a bug in the Linux kernel
that manifests itself as slurm failing to create a memory cgroup, with
an error message like

slurmstepd: error: task/cgroup: unable to add task[pid=1234] to memory cg '(null)'

See slurm bug 5082.