### PR TITLE
Allow using OpenHPC slurm packages

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,35 @@
+Switch from FGCI to OHPC slurm packages
+---------------------------------------
+
+In general, need to be careful with slurmdbd, probably running it in
+the foreground during upgrade to monitor progress. See
+http://slurm.schedmd.com/quickstart_admin.html#upgrade
+
+0. Service break, making sure no jobs are running
+1. Stop slurmdbd
+2. Remove all slurm and munge packages from the slurmdbd node: yum remove '*slurm*' 'munge*'
+3. Install slurm server packages: yum install ohpc-slurm-server
+4. Start slurmdbd in the foreground: /sbin/slurmdbd -D -v
+5. Wait until the DB upgrade is completed (can take up to 45 mins)
+6. Stop the slurmdbd running in the foreground: Ctrl-C
+7. Start slurmdbd via systemd: systemctl start slurmdbd
+8. In group_vars, set slurm_ohpc to "ohpc"
+
+
+Upgrading OHPC slurm packages
+-----------------------------
+
+To upgrade to a newer slurm OHPC version:
+
+1. Do steps 0-1 from previous list above
+2. Delete all the slurm and munge versionlock stuff from /etc/yum/pluginconf.d/versionlock.list
+3. In group_vars set slurm_ohpc_versionlock to False
+4. yum update
+5. Do steps 4-7 from the above list.
+6. Upgrade all the nodes.
+7. In group_vars set slurm_ohpc_versionlock to True and run this role to lock the version again 
+
+
 From 15.08 to 16.05
 -------------------
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,8 +17,9 @@ slurm_manage_mysql_security: True
 # group exist
 nis_server: False
 
-fgci_install: True
 fgci_slurmrepo_version: "fgcislurm1711"
+slurm_repo: "fgci"  # Or "ohpc" to use OHPC slurm packages
+slurm_ohpc_versionlock: True
 siteName: "io"
 nodeBase: "{{ siteName }}"
 nodeGpuBase: "gpu"

--- a/tasks/common.yml
+++ b/tasks/common.yml
@@ -8,18 +8,18 @@
       group: root
       mode: 0644
       backup: yes
-    when: fgci_install == True
+    when: slurm_repo == 'fgci'
 
   - name: Import FGI slurm repo key
     rpm_key:
       key: http://idris.fgi.csc.fi/fgirepo6/RPM-GPG-KEY-CSC-GRID-2
       state: present
-    when: fgci_install == True
+    when: slurm_repo == 'fgci'
 
   - name: Install FGCI repo
     package:
       pkg: http://idris.fgi.csc.fi/fgci7/x86_64/fgci/rpms/fgci-release7-1-1.el7.noarch.rpm
-    when: ansible_distribution_major_version == "7" and fgci_install == True and ansible_os_family == "RedHat"
+    when: ansible_distribution_major_version == "7" and slurm_repo == 'fgci' and ansible_os_family == "RedHat"
 
 ##
   - name: install common Slurm packages
@@ -33,7 +33,7 @@
     package:
       name: slurm-fgi-addons
       state: present
-    when: fgci_install and ansible_distribution_major_version == "7"
+    when: slurm_repo == 'fgci' and ansible_distribution_major_version == "7"
 
   - name: Copy pam.d/slurm
     copy: src=pam_slurm dest=/etc/pam.d/slurm owner=root mode=0644

--- a/tasks/common_ubuntu.yml
+++ b/tasks/common_ubuntu.yml
@@ -3,7 +3,7 @@
 # define where we get .debs for slurm. 
   - name: Add local apt-repo
     template: src=apt.repo.j2 dest=/etc/apt/sources.list.d/fgislurm.list owner=root group=root mode=0644 backup=yes
-    when: fgci_install == True and slurm_apt_repo == True
+    when: slurm_repo == 'fgci' and slurm_apt_repo == True
 
 
 ##
@@ -14,7 +14,7 @@
 
   - name: install fgci Slurm addons
     package: name=slurm-fgi-addons state=present
-    when: fgci_install
+    when: slurm_repo == 'fgci'
 
   - name: Copy pam.d/slurm
     copy: src=pam_slurm dest=/etc/pam.d/slurm owner=root mode=0644

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -19,12 +19,17 @@
   with_first_found:
     - "slurm_{{ slurm_fact_fgci_slurmrepo_version }}.yml"
     - "slurm_default.yml"
+  when: slurm_repo == 'fgci'
+
+- include_vars: slurm_ohpc.yml
+  when: slurm_repo == 'ohpc'
 
   # common.yml is applied to all nodes
     # configure pam
     # template in cgroup.conf, gres.conf and slurm.conf
     # set up logrotate and rsyslog
 - include_tasks: common.yml
+
 
   # upgrade is used to compare slurm version installed and the one ansible wants to install
     # pauses the play on the dbd host
@@ -69,3 +74,12 @@
 - include_tasks: submit.yml
   when: "(ansible_os_family == 'RedHat') and ('slurm_compute' not in group_names) and ('slurm_service' not in group_names)"
 
+- name: Versionlock slurm packages when using OHPC
+  command: yum versionlock add {{ item }}
+  when: slurm_repo == 'ohpc' and slurm_ohpc_versionlock == True
+  loop: "{{ slurm_ohpc_versionlock_list }}"
+
+- name: Remove slurm versionlock for OHPC upgrade
+  command: yum versionlock delete {{ item }}
+  when: slurm_repo == 'ohpc' and slurm_ohpc_versionlock == False
+  loop: "{{ slurm_ohcp_versionlock_list }}"

--- a/vars/slurm_ohpc.yml
+++ b/vars/slurm_ohpc.yml
@@ -1,0 +1,28 @@
+---
+
+slurm_packages:
+  - yum-plugin-versionlock
+  - slurm-ohpc
+
+slurm_service_packages:
+ - lua-devel
+ - mailx
+ - ohpc-slurm-server
+
+slurm_compute_packages:
+ - ohpc-slurm-client
+
+slurm_conf_version_specific_params_list:
+ - "SlurmctldSyslogDebug={{ slurm_slurmctld_syslog_debug }}"
+ - "SlurmdSyslogDebug={{ slurm_slurmd_syslog_debug }}"
+
+slurm_slurmdbd_conf_version_specific_params_list:
+ - "DebugLevelSyslog={{ slurm_slurmdbd_syslog_debug }}"
+
+slurm_cgroup_constrain_kmem_space: "no" # Workaround for Linux kernel bug, see slurm bug #5082
+
+slurm_ohpc_versionlock_list:
+  - 'slurm-ohpc'
+  - 'slurm-*-ohpc'
+  - 'ohpc-slurm-*'
+  - 'munge*ohpc'


### PR DESCRIPTION
Allow using slurm packages from the OpenHPC repository instead of from
the FGCI one.  In order to avoid inadvertent upgrade the package
version are locked using the yum versionlock plugin. Upgrade
instructions are provided in UPGRADE.md.