### PR TITLE
Provide package lists directly to package/apt commands

### DIFF
--- a/tasks/common.yml
+++ b/tasks/common.yml
@@ -77,6 +77,5 @@
     when: slurm_plugstack|bool and slurm_x11_spank|bool
 
   - name: install slurm-spank-x11 and xauth
-    package: name={{ item }} state=present
-    with_items: "{{ slurm_spank_x11_packages }}"
+    package: name={{ slurm_spank_x11_packages }} state=present
     when: slurm_plugstack|bool and slurm_x11_spank|bool

--- a/tasks/common_ubuntu.yml
+++ b/tasks/common_ubuntu.yml
@@ -8,8 +8,7 @@
 
 ##
   - name: install common Slurm packages
-    apt: name={{ item }} state=present update_cache=yes allow_unauthenticated=yes
-    with_items: "{{ slurm_packages }}"
+    apt: name="{{ slurm_packages }}" state=present update_cache=yes allow_unauthenticated=yes
     when: slurm_packages.0 != ""
 
   - name: install fgci Slurm addons
@@ -58,6 +57,5 @@
     when: slurm_plugstack|bool and slurm_x11_spank|bool
 
   - name: install slurm-spank-x11 and xauth
-    package: name={{ item }} state=present
-    with_items: "{{ slurm_spank_x11_packages }}"
+    package: name="{{ slurm_spank_x11_packages }}" state=present
     when: slurm_plugstack|bool and slurm_x11_spank|bool

--- a/tasks/compute.yml
+++ b/tasks/compute.yml
@@ -33,9 +33,8 @@
     when: ansible_connection == 'chroot'
 
   - name: install slurmd packages
-    package: name="{{ item }}" state=present
+    package: name="{{ slurm_compute_packages }}" state=present
     when: slurm_compute_packages is defined
-    with_items: "{{ slurm_compute_packages }}"
 
   - name: Make sure /usr/local/libexec/slurm/epilog.d exists
     file: path=/usr/local/libexec/slurm/epilog.d state=directory owner=root group=root mode=0755 recurse=yes

--- a/tasks/compute_ubuntu.yml
+++ b/tasks/compute_ubuntu.yml
@@ -28,9 +28,8 @@
      - restart munge
 
   - name: install slurmd packages
-    package: name="{{ item }}" state=present
+    package: name="{{ slurm_compute_packages }}" state=present
     when: slurm_compute_packages is defined
-    with_items: "{{ slurm_compute_packages }}"
 
   - name: Make sure /usr/local/libexec/slurm/epilog.d exists
     file: path=/usr/local/libexec/slurm/epilog.d state=directory owner=root group=root mode=0755 recurse=yes

--- a/tasks/dbd.yml
+++ b/tasks/dbd.yml
@@ -6,9 +6,8 @@
 ####
 
   - name: install slurmdbd specific packages
-    package: "name={{item}} state=present"
+    package: name="{{ slurmdbd_packages }}" state=present
     register: reg_install_slurm_packages
-    with_items: "{{ slurmdbd_packages }}"
     when: ansible_os_family == "RedHat"
 
   - name: start and enable mariadb/mysql

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -1,7 +1,6 @@
 ---
   - name: install slurm service specific packages
-    package: "name={{ item }} state=present"
-    with_items: "{{ slurm_service_packages }}"
+    package: name="{{ slurm_service_packages }}" state=present
 
   - name: does the munge.key exist?
     stat: path=/etc/munge/munge.key

--- a/tasks/slurmctld.yml
+++ b/tasks/slurmctld.yml
@@ -1,7 +1,6 @@
 ---
   - name: install specific slurm service_packages for slurmctlds
-    package: "name={{ item }} state=present"
-    with_items: "{{ slurm_service_packages }}"
+    package: name="{{ slurm_service_packages }}" state=present
 
   - name: Install munge key for slurmctld
     copy:


### PR DESCRIPTION
Instead of looping with a with_items construct, these ansible commands
can take a list directly which is more efficient than invoking yum/apt
separately for each item.