### PR TITLE
Remove incorrect setting of MailProg

### DIFF
--- a/templates/slurm.conf.j2
+++ b/templates/slurm.conf.j2
@@ -50,7 +50,6 @@ HealthCheckInterval={{ slurm_healthcheck_interval }}
 HealthCheckProgram={{ slurm_healthcheck_program }}
 {% endif %}
 GresTypes={{ slurm_grestypes }}
-MailProg=/usr/bin/smail
 
 # TIMERS
 SlurmctldTimeout={{ slurm_SlurmctldTimeout }}


### PR DESCRIPTION
In the vars/ files we install the mailx package, which provides
/bin/mail, which is also the default setting of MailProg if it's not
present in slurm.conf. OTOH the current setting of /usr/bin/smail
generates an error because that binary is not provided by mailx. Hence
just remove this setting and use the default.