### PR TITLE
Cleanup package lists for ohpc

### DIFF
--- a/vars/slurm_ohpc.yml
+++ b/vars/slurm_ohpc.yml
@@ -11,13 +11,9 @@ slurm_service_packages:
  - lua-devel
  - mailx
  - ohpc-slurm-server
- - slurm-libpmi-ohpc
- - slurm-ohpc-fgci-addons
 
 slurm_compute_packages:
  - ohpc-slurm-client
- - slurm-libpmi-ohpc
- - slurm-ohpc-fgci-addons
 
 slurm_conf_version_specific_params_list:
  - "SlurmctldSyslogDebug={{ slurm_slurmctld_syslog_debug }}"


### PR DESCRIPTION
Remove slurm-libpmi-ohpc and slurm-ohpc-fgci-addons from
slurm_service_packages and slurm_compute_packages since they are
already in the slurm_packages list which gets installed everywhere.