### PR TITLE
Hello Ansible Galaxy

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,23 +3,8 @@ galaxy_info:
   author: Johan Guldmyr
   description:  Installs and configures slurm on a cluster
   company: CSC - IT Center for Science Ltd.
-  # If the issue tracker for your role is not on github, uncomment the
-  # next line and provide a value
-  # issue_tracker_url: http://example.com/issue/tracker
-  # Some suggested licenses:
-  # - BSD (default)
-  # - MIT
-  # - GPLv2
-  # - GPLv3
-  # - Apache
-  # - CC-BY
   license: MIT
   min_ansible_version: 2.4
-  #
-  # Below are all platforms currently available. Just uncomment
-  # the ones that apply to your role. If you don't see your 
-  # platform on this list, let us know and we'll get it added!
-  #
   platforms:
   - name: EL
     versions:
@@ -27,103 +12,18 @@ galaxy_info:
   #  - 5
   #  - 6
   #  - 7
-  #- name: GenericUNIX
-  #  versions:
-  #  - all
-  #  - any
-  #- name: Fedora
-  #  versions:
-  #  - all
-  #  - 16
-  #  - 17
-  #  - 18
-  #  - 19
-  #  - 20
-  #  - 21
-  #  - 22
-  #- name: Windows
-  #  versions:
-  #  - all
-  #  - 2012R2
-  #- name: SmartOS
-  #  versions:
-  #  - all
-  #  - any
-  #- name: opensuse
-  #  versions:
-  #  - all
-  #  - 12.1
-  #  - 12.2
-  #  - 12.3
-  #  - 13.1
-  #  - 13.2
-  #- name: Amazon
-  #  versions:
-  #  - all
-  #  - 2013.03
-  #  - 2013.09
-  #- name: GenericBSD
-  #  versions:
-  #  - all
-  #  - any
-  #- name: FreeBSD
-  #  versions:
-  #  - all
-  #  - 8.0
-  #  - 8.1
-  #  - 8.2
-  #  - 8.3
-  #  - 8.4
-  #  - 9.0
-  #  - 9.1
-  #  - 9.1
-  #  - 9.2
   #- name: Ubuntu
   #  versions:
   #  - all
-  #  - lucid
-  #  - maverick
-  #  - natty
-  #  - oneiric
-  #  - precise
-  #  - quantal
-  #  - raring
-  #  - saucy
-  #  - trusty
-  #  - utopic
-  #  - vivid
-  #- name: SLES
-  #  versions:
-  #  - all
-  #  - 10SP3
-  #  - 10SP4
-  #  - 11
-  #  - 11SP1
-  #  - 11SP2
-  #  - 11SP3
-  #- name: GenericLinux
-  #  versions:
-  #  - all
-  #  - any
   #- name: Debian
   #  versions:
   #  - all
-  #  - etch
-  #  - jessie
-  #  - lenny
-  #  - squeeze
   #  - wheezy
-  #
-  # Below are all categories currently available. Just as with
-  # the platforms above, uncomment those that apply to your role.
   #
   galaxy_tags:
    - clustering
    - system
-dependencies:
-  # List your role dependencies here, one per line.
-  # Be sure to remove the '[]' above if you add dependencies
-  # to this list.
-  - src: git+https://github.com/jabl/ansible-role-pam.git
-    name: ansible-role-pam
-
+   - batch
+   - hpc
+   - slurm
+dependencies: []

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -124,5 +124,6 @@ dependencies:
   # List your role dependencies here, one per line.
   # Be sure to remove the '[]' above if you add dependencies
   # to this list.
-  - { src: git+https://github.com/jabl/ansible-role-pam.git, name: ansible-role-pam }
- 
+  - src: git+https://github.com/jabl/ansible-role-pam.git
+    name: ansible-role-pam
+

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -124,5 +124,5 @@ dependencies:
   # List your role dependencies here, one per line.
   # Be sure to remove the '[]' above if you add dependencies
   # to this list.
-  - { src: ansible-role-pam, name: ansible-role-pam }
+  - { src: git+https://github.com/jabl/ansible-role-pam.git, name: ansible-role-pam }
  


### PR DESCRIPTION
Galaxy doesn't like the way we say ansible-role-pam is a dependency:

<pre>
Starting import: task_id=525198, repository=CSCfi/ansible-role-slurm 
 
===== LOADING ROLE ===== 
Task "525198" failed: Expecting dependency name format to match "username.role_name", got ansible-role-pam 
</pre>

This PR tries out a new syntax where we specify the role-pam used in fgci-ansible: https://github.com/CSCfi/fgci-ansible/blob/master/requirements.yml#L178

It does not specify a version, but it is possible to also do that: https://docs.ansible.com/ansible/latest/galaxy/user_guide.html#dependencies

Is this dependency listing in meta/main.yml even needed anymore? We haven't listed the NHC role in there but it's in the requirements.yml. 