### PR TITLE
option to set uig/gid manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,12 @@ ansible-role-slurm
 
 Tested with these Linux distributions:
  - CentOS 6
-  - Only 14.11.x
+   - Only 14.11.x
  - CentOS 7
-  - 17.02.x (travis ci automatic testing)
-  - 17.11.x (travis ci automatic testing)
+   - 17.02.x (travis ci automatic testing)
+   - 17.11.x (travis ci automatic testing)
+ - Ubuntu
+   - 18.04 (client only)
 
 The role goes to some lengths to be backwards compatible.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,6 +17,10 @@ slurm_manage_mysql_security: True
 # group exist
 nis_server: False
 
+# option to manually force slurm_user_uid regardless of nis server
+#slurm_user_uid: 5004
+#slurm_user_gid: 5004
+
 fgci_slurmrepo_version: "fgcislurm1711"
 slurm_repo: "fgci"  # Or "ohpc" to use OHPC slurm packages
 slurm_ohpc_versionlock: True

--- a/tasks/common.yml
+++ b/tasks/common.yml
@@ -28,6 +28,17 @@
     when: ansible_distribution_major_version == "7" and slurm_repo == 'fgci' and ansible_os_family == "RedHat"
 
 ##
+    # Set slurm user and group locally on every host if uid/gid given
+  - name: add slurm unix group
+    group: name=slurm system=no state=present gid={{ slurm_user_gid|default(slurm_user_uid) }}                                                                                 
+    register: reg_slurm_unixgroup
+    when: slurm_user_uid is defined
+
+  - name: add slurm unix user
+    user: name=slurm shell=/sbin/nologin createhome=no system=no append=yes group=slurm state=present uid={{ slurm_user_uid }}                                                 
+    register: reg_slurm_unixuser
+    when: slurm_user_uid is defined
+
   - name: install common Slurm packages
     package:
        name:  "{{ slurm_packages }}"

--- a/tasks/common_ubuntu.yml
+++ b/tasks/common_ubuntu.yml
@@ -7,6 +7,17 @@
 
 
 ##
+    # Set slurm user and group locally on every host if uid/gid given
+  - name: add slurm unix group
+    group: name=slurm system=no state=present gid={{ slurm_user_gid|default(slurm_user_uid) }}
+    register: reg_slurm_unixgroup
+    when: slurm_user_uid is defined
+
+  - name: add slurm unix user
+    user: name=slurm shell=/sbin/nologin createhome=no system=no append=yes group=slurm state=present uid={{ slurm_user_uid }}                                                 $
+    register: reg_slurm_unixuser
+    when: slurm_user_uid is defined
+
   - name: install common Slurm packages
     apt: name="{{ slurm_packages }}" state=present update_cache=yes allow_unauthenticated=yes
     when: slurm_packages.0 != ""

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -30,10 +30,12 @@
   - name: add slurm unix group
     group: name=slurm system=no state=present
     register: reg_slurm_unixgroup
+    when: slurm_user_uid is not defined
 
   - name: add slurm unix user
     user: name=slurm shell=/sbin/nologin createhome=no system=no append=yes group=slurm state=present
     register: reg_slurm_unixuser
+    when: slurm_user_uid is not defined
 
   - name: add slurm log dir
     file: "path={{ slurm_log_dir }} state=directory owner=slurm group=slurm mode=0750"


### PR DESCRIPTION
Allow creations of local slurm user with given uid/gid. Needed if there is no common auth-server in use at installation time (including when creating e.g. ohpc images). 