### PR TITLE
x11 spank plugin is not correctly turned off

### DIFF
--- a/tasks/common.yml
+++ b/tasks/common.yml
@@ -102,7 +102,7 @@
     file:
       path: /etc/slurm/plugstack.conf.d/x11.conf
       state: absent
-    when: slurm_plugstack|bool == false and slurm_x11_spank|bool == false
+    when: slurm_plugstack|bool == false or slurm_x11_spank|bool == false
 
   - name: install slurm-spank-x11 and xauth
     package: name={{ slurm_spank_x11_packages }} state=present


### PR DESCRIPTION
x11.conf not removed from /etc/slurm/plugstack.conf.d even if x11 spank plugin is turned off. Both conditions should be enough alone to remove plugin configuration.