### PR TITLE
some parameters deprecated on Slurm >=21.08

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,6 +28,9 @@ siteName: "io"
 nodeBase: "{{ siteName }}"
 nodeGpuBase: "gpu"
 
+# this role has been written to support slurm >=18.08. Some conf parameters have been deprecated from newer Slurm versions so this is for backward compatibility
+slurm_major_version: 18
+
 # Have systemd restart slurm daemons if they fail to start
 slurm_systemd_override_slurmd: True
 slurm_systemd_override_slurmdbd: True

--- a/templates/slurm.conf.j2
+++ b/templates/slurm.conf.j2
@@ -30,7 +30,9 @@ MpiParams={{ slurm_mpi_params }}
 SlurmctldPidFile={{ slurm_SlurmctldPidFile }}
 SlurmdPidFile={{ slurm_SlurmdPidFile }}
 ProctrackType={{ slurm_proctrack_type }}
+{% if slurm_major_version|int < 21 %}
 CacheGroups={{ slurm_CacheGroups }}
+{% endif %}
 FirstJobId={{ slurm_first_job_id }}
 ReturnToService={{ slurm_return_to_service }}
 MaxJobCount={{ slurm_max_job_count }}
@@ -70,7 +72,9 @@ SchedulerType={{ slurm_SchedulerType }}
 SchedulerParameters={{ slurm_scheduler_parameters }}
 SelectType={{ slurm_select_type }}
 SelectTypeParameters={{ slurm_select_type_parameters }}
+{% if slurm_major_version|int < 21 %}
 FastSchedule={{ slurm_fast_schedule }}
+{% endif %}
 PriorityType={{ slurm_priority_type }}
 {% if slurm_priority_type == "priority/multifactor" %}
 PriorityFlags={{ slurm_priority_flags }}
@@ -97,7 +101,9 @@ AcctGatherEnergyType={{ slurm_AcctGatherEnergyType }}
 AcctGatherNodeFreq={{ slurm_AcctGatherNodeFreq }}
 AccountingStorageType={{ slurm_accounting_storage_type }}
 AccountingStorageHost={{ slurm_accounting_storage_host }}
+{% if slurm_major_version|int < 21 %}
 AccountingStorageLoc={{ slurm_accounting_storage_loc }}
+{% endif %}
 AccountingStorageUser={{ slurm_accounting_storage_user }}
 AccountingStorageEnforce={{ slurm_accounting_storage_enforce }}
 {% if slurm_accounting_storage_tres is defined %}


### PR DESCRIPTION
Some parameters get deprecated on newer Slurm. Add if statetement to handle this. Currently many run 18.08 version, so setting this as default. No config changes needed on sites running 18.08 but allow updating to 21.08 wrt configs.